### PR TITLE
Accepting stdin as input

### DIFF
--- a/alan
+++ b/alan
@@ -70,12 +70,17 @@ if [[ "$SHIFT" -le 0 ]]; then
 	echo "Error: Value for -s must be a positive integer!"
 	exit; fi
 
-INFILE=$1
+# save filename as $INFILE or substitute for stdin if not present
+INFILE=${1:-/dev/stdin}
 
-# Check the input file is specified and is present
+# Check the input file is specified and present or stdin is open
 if [[ ! -f $INFILE || "$INFILE" == "" ]]; then
-	echo "Error: Please specify a valid input file! :)"
-	exit; fi
+	if [[ ! -t 0 ]]; then
+		echo "Read from stdin"
+	else
+		echo "Error: Please specify a valid input file! :)"
+		exit; fi
+	fi
 
 # Choose between clustal and fasta...
 CLUSTAL=0
@@ -137,7 +142,7 @@ function go_clustal {
 }
 
 if [[ "$CLUSTAL" -eq 1 ]]; then
-	go_clustal $1
+	go_clustal "$INFILE"
 else
-	go_fasta $1
+	go_fasta "$INFILE"
 fi


### PR DESCRIPTION
Without major refactoring of code, I was able to at least move past the errors in allowing stdin input.

So far though, I've only been able to get `alan < seqs.fasta` to work.

I added in a test to the test determining if the input file is empty or not. If stdin as provided via pipe, that message shows, but if provided via `alan < fasta` the message does not show, it simply works

```
### nothing happens besides the error
./alan_stdin
Error: Please specify a valid input file! :)

### less opens, but with no text
cat test_seq.pep | alan_stdin /dev/stdin
#> Read from stdin
cat test_seq.pep | alan_stdin
#> Read from stdin

#### works with highlights
./alan_stdin test_seq.pep
alan_stdin < test_seq.pep
```